### PR TITLE
タスク検索メソッドのセキュリティ脆弱性を修正

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -22,7 +22,7 @@ class Task < ApplicationRecord
     if name == "" || name.nil?
       all
     else
-      where("name like '%" + name+ "%'")
+      where("name like ?", "%#{name}%")
     end
   end
 
@@ -30,7 +30,7 @@ class Task < ApplicationRecord
     if description == "" || description.nil?
       all
     else
-      where("description like '%" + description+ "%'")
+      where("description like ?", "%#{description}%")
     end
   end
 
@@ -46,7 +46,7 @@ class Task < ApplicationRecord
     if label == "" || label.nil?
       all
     else
-      labels = current_user.labels.where(name: label).ids
+      labels = current_user.labels.where("name = ?", label).ids
       task_ids = LabelTask.where(label_id: labels).map {|t| p t.task_id }
       Task.where(id: task_ids)
     end


### PR DESCRIPTION
## 概要
関連 issue #33 
タスク検索メソッドの脆弱性を修正する

## やったこと
- `Task#search` にSQLインジェクションの恐れがあるコードが含まれるので、プレースホルダーを使った形に置き換える

## やっていないこと
- タスク検索メソッドのリファクタリング
  - 現状メソッドが属性ごとに存在していてリファクタリングの余地があるが、PR の粒度が大きくなりすぎるため、別の PR で行う

## 気になる点
- プレースホルダーを使った形は初めて書く & 重大なセキュリティ脆弱性に関わる変更なので、これで間違いないか厳しくチェックしてほしいです。